### PR TITLE
Switch to `start: php-server`

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -14,9 +14,7 @@ data.db:
 
 # add a worker component and give it a "start" command
 web.main:
-  start:
-    nginx: start-apache
-    fpm: start-php
+  start: php-server
 
   # add writable dirs to your web component
   writable_dirs:


### PR DESCRIPTION
The `start-*` commands have been superseded by `php-server`, which will automatically launch whichever combination of PHP and web server the user has configured in the `run.config` section of the Boxfile.